### PR TITLE
Fix CSV fields

### DIFF
--- a/accession/admin_views.py
+++ b/accession/admin_views.py
@@ -82,10 +82,15 @@ def export_csv(request, app, model):
     model_admin = accession_admin._registry[model]
     results, _ = model_admin.get_search_results(request, objects_list, q)
 
+    # Retrieve the configuration object for the given model.
     csv_config = get_csv_config(model)
 
+    # Use the fields list from the configuration object to filter the fields
+    # that are shown in the queryset.
     results = results.values(*csv_config.fields)
 
+    # Use the two dicts from the configuration object to define new columns in
+    # the csv doc and rename the fields to be more readable.
     return render_to_csv_response(
         results,
         field_header_map=csv_config.header_map,

--- a/accession/admin_views.py
+++ b/accession/admin_views.py
@@ -7,7 +7,7 @@ from django.shortcuts import render
 from django.contrib.admin.views.decorators import staff_member_required
 
 from accession.admin import accession_admin
-from accession.export_csv_utils import get_object_by_model
+from accession.export_csv_utils import get_csv_config
 
 
 @staff_member_required
@@ -82,9 +82,12 @@ def export_csv(request, app, model):
     model_admin = accession_admin._registry[model]
     results, _ = model_admin.get_search_results(request, objects_list, q)
 
-    obj = get_object_by_model(model)
+    csv_config = get_csv_config(model)
 
-    results = results.values(*obj.fields_to_show)
+    results = results.values(*csv_config.fields_to_show)
 
-    return render_to_csv_response(results, field_header_map=obj.field_header_map,
-                                  field_serializer_map=obj.field_serializer_map)
+    return render_to_csv_response(
+        results,
+        field_header_map=csv_config.field_header_map,
+        field_serializer_map=csv_config.field_serializer_map
+    )

--- a/accession/admin_views.py
+++ b/accession/admin_views.py
@@ -84,10 +84,10 @@ def export_csv(request, app, model):
 
     csv_config = get_csv_config(model)
 
-    results = results.values(*csv_config.fields_to_show)
+    results = results.values(*csv_config.fields)
 
     return render_to_csv_response(
         results,
-        field_header_map=csv_config.field_header_map,
-        field_serializer_map=csv_config.field_serializer_map
+        field_header_map=csv_config.header_map,
+        field_serializer_map=csv_config.serializer_map
     )

--- a/accession/admin_views.py
+++ b/accession/admin_views.py
@@ -7,7 +7,7 @@ from django.shortcuts import render
 from django.contrib.admin.views.decorators import staff_member_required
 
 from accession.admin import accession_admin
-from accession.models import Accession, Donor, Object
+from accession.export_csv_utils import get_object_by_model
 
 
 @staff_member_required
@@ -82,59 +82,9 @@ def export_csv(request, app, model):
     model_admin = accession_admin._registry[model]
     results, _ = model_admin.get_search_results(request, objects_list, q)
 
-    # Modify the querysets to show something more meaningful than object IDs.
-    field_serializer_map = {}
-    field_header_map = {}
+    obj = get_object_by_model(model)
 
-    if model == Accession:
-        field_serializer_map = {'donor_id': (lambda x: str(Donor.objects.get(id=x)))}
-        field_header_map = {'donor_id': 'donor'}
+    results = results.values(*obj.fields_to_show)
 
-    elif model == Donor:
-        fields_to_show = [
-            'id', 'salutation', 'first_name', 'middle_name', 'last_name',
-            'organization_name', 'donor_type', 'gender', 'address_1',
-            'address_2', 'city__city', 'state', 'postal_code',
-            'country__country', 'phone_number_1', 'phone_number_2',
-            'email_address', 'comments'
-        ]
-
-        field_header_map = {'city__city': 'city', 'country__country': 'country'}
-
-        results = results.values(*fields_to_show)
-
-    elif model == Object:
-        fields_to_show = [
-            'id', 'object_number', 'accession_number__accession_number',
-            'object_description', 'related_objects', 'original_numbers',
-            'date_object_creation', 'object_era', 'remarks', 'location_remarks',
-            'construction', 'exhibitions', 'publications', 'provenance',
-            'condition_statement', 'price', 'public_notes',
-            'designer__designer', 'label__label', 'retailer__retailer_name',
-            'retailer_label__retailer_label', 'classification__classification',
-            'country__country', 'gender', 'location__location',
-            'condition__condition', 'material__material',
-            'measurement__measurement', 'type__object_type', 'parts__part',
-            'date_record_added', 'date_record_last_edited'
-        ]
-
-        field_header_map = {
-            'accession_number__accession_number': 'accession number',
-            'designer__designer': 'designer',
-            'label__label': 'label',
-            'retailer__retailer_name': 'retailer',
-            'retailer_label__retailer_label': 'retailer label',
-            'classification__classification': 'classification',
-            'country__country': 'country',
-            'location__location': 'location',
-            'condition__condition': 'condition',
-            'material__material': 'material',
-            'measurement__measurement': 'measurement',
-            'type__object_type': 'type',
-            'parts__part': 'parts'
-        }
-
-        results = results.values(*fields_to_show)
-
-    return render_to_csv_response(results, field_header_map=field_header_map,
-                                  field_serializer_map=field_serializer_map)
+    return render_to_csv_response(results, field_header_map=obj.field_header_map,
+                                  field_serializer_map=obj.field_serializer_map)

--- a/accession/admin_views.py
+++ b/accession/admin_views.py
@@ -7,6 +7,7 @@ from django.shortcuts import render
 from django.contrib.admin.views.decorators import staff_member_required
 
 from accession.admin import accession_admin
+from accession.models import Accession, Donor, Object
 
 
 @staff_member_required
@@ -80,4 +81,60 @@ def export_csv(request, app, model):
     # Using one of Django's private API's (_registry). May break with updates.
     model_admin = accession_admin._registry[model]
     results, _ = model_admin.get_search_results(request, objects_list, q)
-    return render_to_csv_response(results)
+
+    # Modify the querysets to show something more meaningful than object IDs.
+    field_serializer_map = {}
+    field_header_map = {}
+
+    if model == Accession:
+        field_serializer_map = {'donor_id': (lambda x: str(Donor.objects.get(id=x)))}
+        field_header_map = {'donor_id': 'donor'}
+
+    elif model == Donor:
+        fields_to_show = [
+            'id', 'salutation', 'first_name', 'middle_name', 'last_name',
+            'organization_name', 'donor_type', 'gender', 'address_1',
+            'address_2', 'city__city', 'state', 'postal_code',
+            'country__country', 'phone_number_1', 'phone_number_2',
+            'email_address', 'comments'
+        ]
+
+        field_header_map = {'city__city': 'city', 'country__country': 'country'}
+
+        results = results.values(*fields_to_show)
+
+    elif model == Object:
+        fields_to_show = [
+            'id', 'object_number', 'accession_number__accession_number',
+            'object_description', 'related_objects', 'original_numbers',
+            'date_object_creation', 'object_era', 'remarks', 'location_remarks',
+            'construction', 'exhibitions', 'publications', 'provenance',
+            'condition_statement', 'price', 'public_notes',
+            'designer__designer', 'label__label', 'retailer__retailer_name',
+            'retailer_label__retailer_label', 'classification__classification',
+            'country__country', 'gender', 'location__location',
+            'condition__condition', 'material__material',
+            'measurement__measurement', 'type__object_type', 'parts__part',
+            'date_record_added', 'date_record_last_edited'
+        ]
+
+        field_header_map = {
+            'accession_number__accession_number': 'accession number',
+            'designer__designer': 'designer',
+            'label__label': 'label',
+            'retailer__retailer_name': 'retailer',
+            'retailer_label__retailer_label': 'retailer label',
+            'classification__classification': 'classification',
+            'country__country': 'country',
+            'location__location': 'location',
+            'condition__condition': 'condition',
+            'material__material': 'material',
+            'measurement__measurement': 'measurement',
+            'type__object_type': 'type',
+            'parts__part': 'parts'
+        }
+
+        results = results.values(*fields_to_show)
+
+    return render_to_csv_response(results, field_header_map=field_header_map,
+                                  field_serializer_map=field_serializer_map)

--- a/accession/admin_views.py
+++ b/accession/admin_views.py
@@ -7,7 +7,7 @@ from django.shortcuts import render
 from django.contrib.admin.views.decorators import staff_member_required
 
 from accession.admin import accession_admin
-from accession.export_csv_utils import get_csv_config
+from accession.utils import get_csv_config
 
 
 @staff_member_required

--- a/accession/export_csv_utils.py
+++ b/accession/export_csv_utils.py
@@ -15,18 +15,18 @@ def get_csv_config(model):
         return GenericCSVConfig
 
 
-class AccessionCSVConfig:
-    fields_to_show = []
-    field_serializer_map = {
+class AccessionCSVConfig(object):
+    fields = []
+    serializer_map = {
         'donor_id': (lambda x: str(Donor.objects.get(id=x)))
     }
-    field_header_map = {
+    header_map = {
         'donor_id': 'donor'
     }
 
 
-class DonorCSVConfig:
-    fields_to_show = [
+class DonorCSVConfig(object):
+    fields = [
         'id',
         'salutation',
         'first_name',
@@ -46,15 +46,15 @@ class DonorCSVConfig:
         'email_address',
         'comments'
     ]
-    field_serializer_map = {}
-    field_header_map = {
+    serializer_map = {}
+    header_map = {
         'city__city': 'city',
         'country__country': 'country'
     }
 
 
-class ObjectCSVConfig:
-    fields_to_show = [
+class ObjectCSVConfig(object):
+    fields = [
         'id',
         'object_number',
         'accession_number__accession_number',
@@ -88,8 +88,8 @@ class ObjectCSVConfig:
         'date_record_added',
         'date_record_last_edited'
     ]
-    field_serializer_map = {}
-    field_header_map = {
+    serializer_map = {}
+    header_map = {
         'accession_number__accession_number': 'accession number',
         'designer__designer': 'designer',
         'label__label': 'label',
@@ -106,7 +106,7 @@ class ObjectCSVConfig:
     }
 
 
-class GenericCSVConfig:
-    fields_to_show = []
-    field_serializer_map = {}
-    field_header_map = {}
+class GenericCSVConfig(object):
+    fields = []
+    serializer_map = {}
+    header_map = {}

--- a/accession/export_csv_utils.py
+++ b/accession/export_csv_utils.py
@@ -1,51 +1,92 @@
 from accession.models import Accession, Donor, Object
 
 
-def get_object_by_model(model):
+def get_csv_config(model):
     if model == Accession:
-        return ACC
+        return AccessionCSVConfig
 
     elif model == Donor:
-        return DON
+        return DonorCSVConfig
 
     elif model == Object:
-        return OBJ
+        return ObjectCSVConfig
 
     else:
-        return NORM
+        return GenericCSVConfig
 
 
-class ACC:
+class AccessionCSVConfig:
     fields_to_show = []
-    field_serializer_map = {'donor_id': (lambda x: str(Donor.objects.get(id=x)))}
-    field_header_map = {'donor_id': 'donor'}
+    field_serializer_map = {
+        'donor_id': (lambda x: str(Donor.objects.get(id=x)))
+    }
+    field_header_map = {
+        'donor_id': 'donor'
+    }
 
 
-class DON:
+class DonorCSVConfig:
     fields_to_show = [
-        'id', 'salutation', 'first_name', 'middle_name', 'last_name',
-        'organization_name', 'donor_type', 'gender', 'address_1',
-        'address_2', 'city__city', 'state', 'postal_code',
-        'country__country', 'phone_number_1', 'phone_number_2',
-        'email_address', 'comments'
+        'id',
+        'salutation',
+        'first_name',
+        'middle_name',
+        'last_name',
+        'organization_name',
+        'donor_type',
+        'gender',
+        'address_1',
+        'address_2',
+        'city__city',
+        'state',
+        'postal_code',
+        'country__country',
+        'phone_number_1',
+        'phone_number_2',
+        'email_address',
+        'comments'
     ]
     field_serializer_map = {}
-    field_header_map = {'city__city': 'city', 'country__country': 'country'}
+    field_header_map = {
+        'city__city': 'city',
+        'country__country': 'country'
+    }
 
 
-class OBJ:
+class ObjectCSVConfig:
     fields_to_show = [
-        'id', 'object_number', 'accession_number__accession_number',
-        'object_description', 'related_objects', 'original_numbers',
-        'date_object_creation', 'object_era', 'remarks', 'location_remarks',
-        'construction', 'exhibitions', 'publications', 'provenance',
-        'condition_statement', 'price', 'public_notes',
-        'designer__designer', 'label__label', 'retailer__retailer_name',
-        'retailer_label__retailer_label', 'classification__classification',
-        'country__country', 'gender', 'location__location',
-        'condition__condition', 'material__material',
-        'measurement__measurement', 'type__object_type', 'parts__part',
-        'date_record_added', 'date_record_last_edited'
+        'id',
+        'object_number',
+        'accession_number__accession_number',
+        'object_description',
+        'related_objects',
+        'original_numbers',
+        'date_object_creation',
+        'object_era',
+        'remarks',
+        'location_remarks',
+        'construction',
+        'exhibitions',
+        'publications',
+        'provenance',
+        'condition_statement',
+        'price',
+        'public_notes',
+        'designer__designer',
+        'label__label',
+        'retailer__retailer_name',
+        'retailer_label__retailer_label',
+        'classification__classification',
+        'country__country',
+        'gender',
+        'location__location',
+        'condition__condition',
+        'material__material',
+        'measurement__measurement',
+        'type__object_type',
+        'parts__part',
+        'date_record_added',
+        'date_record_last_edited'
     ]
     field_serializer_map = {}
     field_header_map = {
@@ -65,7 +106,7 @@ class OBJ:
     }
 
 
-class NORM:
+class GenericCSVConfig:
     fields_to_show = []
     field_serializer_map = {}
     field_header_map = {}

--- a/accession/export_csv_utils.py
+++ b/accession/export_csv_utils.py
@@ -1,0 +1,71 @@
+from accession.models import Accession, Donor, Object
+
+
+def get_object_by_model(model):
+    if model == Accession:
+        return ACC
+
+    elif model == Donor:
+        return DON
+
+    elif model == Object:
+        return OBJ
+
+    else:
+        return NORM
+
+
+class ACC:
+    fields_to_show = []
+    field_serializer_map = {'donor_id': (lambda x: str(Donor.objects.get(id=x)))}
+    field_header_map = {'donor_id': 'donor'}
+
+
+class DON:
+    fields_to_show = [
+        'id', 'salutation', 'first_name', 'middle_name', 'last_name',
+        'organization_name', 'donor_type', 'gender', 'address_1',
+        'address_2', 'city__city', 'state', 'postal_code',
+        'country__country', 'phone_number_1', 'phone_number_2',
+        'email_address', 'comments'
+    ]
+    field_serializer_map = {}
+    field_header_map = {'city__city': 'city', 'country__country': 'country'}
+
+
+class OBJ:
+    fields_to_show = [
+        'id', 'object_number', 'accession_number__accession_number',
+        'object_description', 'related_objects', 'original_numbers',
+        'date_object_creation', 'object_era', 'remarks', 'location_remarks',
+        'construction', 'exhibitions', 'publications', 'provenance',
+        'condition_statement', 'price', 'public_notes',
+        'designer__designer', 'label__label', 'retailer__retailer_name',
+        'retailer_label__retailer_label', 'classification__classification',
+        'country__country', 'gender', 'location__location',
+        'condition__condition', 'material__material',
+        'measurement__measurement', 'type__object_type', 'parts__part',
+        'date_record_added', 'date_record_last_edited'
+    ]
+    field_serializer_map = {}
+    field_header_map = {
+        'accession_number__accession_number': 'accession number',
+        'designer__designer': 'designer',
+        'label__label': 'label',
+        'retailer__retailer_name': 'retailer',
+        'retailer_label__retailer_label': 'retailer label',
+        'classification__classification': 'classification',
+        'country__country': 'country',
+        'location__location': 'location',
+        'condition__condition': 'condition',
+        'material__material': 'material',
+        'measurement__measurement': 'measurement',
+        'type__object_type': 'type',
+        'parts__part': 'parts'
+    }
+
+
+class NORM:
+    fields_to_show = []
+    field_serializer_map = {}
+    field_header_map = {}

--- a/accession/utils.py
+++ b/accession/utils.py
@@ -4,16 +4,7 @@ from accession.models import Accession, Donor, Object
 
 
 def get_csv_config(model):
-    """Returns configurations for exporting querysets to csv based on the model.
-
-    This function takes a model and returns a list and two dictionaries. The
-    list (fields) dictates which fields are to be returned in a queryset from
-    the given model. The first dictionary (serializer_map) maps new fields to
-    their data, and is used here to return the string representation of a
-    foreign key in the Accession model. The second dictionary (header_map)
-    renames field names. It is used to make the final csv output more easily
-    readable. The list and dictionaries are determined by what model is given.
-    """
+    """Returns a configuration object based on the given model."""
     if model == Accession:
         return AccessionCSVConfig
 

--- a/accession/utils.py
+++ b/accession/utils.py
@@ -1,18 +1,19 @@
-"""Returns configurations for exporting querysets to csv based on the model.
+"""This module is for code which assists the views."""
 
-This module has one function (get_csv_config) which takes a model and returns
-a list and two dictionaries. The list (fields) dictates which fields are
-to be returned in a queryset from the given model. The first dictionary
-(serializer_map) maps new fields to their data, and is used here to return
-the string representation of a foreign key in the Accession model. The second
-dictionary (header_map) renames field names. It is used to make the final csv
-output more easily readable. The list and dictionaries are determined by what
-model is given.
-"""
 from accession.models import Accession, Donor, Object
 
 
 def get_csv_config(model):
+    """Returns configurations for exporting querysets to csv based on the model.
+
+    This function takes a model and returns a list and two dictionaries. The
+    list (fields) dictates which fields are to be returned in a queryset from
+    the given model. The first dictionary (serializer_map) maps new fields to
+    their data, and is used here to return the string representation of a
+    foreign key in the Accession model. The second dictionary (header_map)
+    renames field names. It is used to make the final csv output more easily
+    readable. The list and dictionaries are determined by what model is given.
+    """
     if model == Accession:
         return AccessionCSVConfig
 

--- a/accession/utils.py
+++ b/accession/utils.py
@@ -1,3 +1,14 @@
+"""Returns configurations for exporting querysets to csv based on the model.
+
+This module has one function (get_csv_config) which takes a model and returns
+a list and two dictionaries. The list (fields) dictates which fields are
+to be returned in a queryset from the given model. The first dictionary
+(serializer_map) maps new fields to their data, and is used here to return
+the string representation of a foreign key in the Accession model. The second
+dictionary (header_map) renames field names. It is used to make the final csv
+output more easily readable. The list and dictionaries are determined by what
+model is given.
+"""
 from accession.models import Accession, Donor, Object
 
 


### PR DESCRIPTION
When exporting data from a model that has foreign key references, the foreign key's ID is printed. We want it to print one of the more useful string fields instead for each of the foreign keys.
